### PR TITLE
Resolve dependency ranges.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,13 +6,18 @@
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/data.xml "0.0.7"]
                  [colorize "0.1.1" :exclusions [org.clojure/clojure]]
-                 [clj-aws-s3 "0.3.7"]
-                 [version-clj "0.1.0"]]
+                 [version-clj "0.1.0" :exclusions [org.clojure/clojure]]
+                 [clj-aws-s3 "0.3.7" :exclusions [org.clojure/clojure]]
+                 ;; Override old clj-aws-s3 dependencies for plugin use.
+                 [org.apache.httpcomponents/httpclient "4.3.1"]
+                 [commons-codec "1.8"]]
   :repositories  {"sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"}
-  :profiles {:dev {:dependencies [[midje "1.5.1"]]
+  :profiles {:dev {:dependencies [[midje "1.5.1"]
+                                  [org.codehaus.plexus/plexus-utils "3.0.15"]]
                    :plugins [[lein-midje "3.1.1"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0-master-SNAPSHOT"]]}}
   :aliases {"midje-dev" ["with-profile" "dev,1.4:dev,1.5:dev,1.6" "midje"]
-            "deps-dev" ["with-profile" "dev,1.4:dev,1.5:dev,1.6" "deps"]})
+            "deps-dev" ["with-profile" "dev,1.4:dev,1.5:dev,1.6" "deps"]}
+  :pedantic? :abort)


### PR DESCRIPTION
This resolves issues with dependency ranges arising from clj-aws-s3 and adds `:pedantic?`.  This prevents needing to use `:exclusions` when requiring ancient-clj (and thus lein-ancient).
