### PR TITLE
Check release tag in maven-metadata.xml unless snapshots are requested

### DIFF
--- a/src/ancient_clj/repository.clj
+++ b/src/ancient_clj/repository.clj
@@ -101,10 +101,9 @@
            versions
            (let [[repo & rst] repos]
              (if-let [repo-versions (when-let [mta (retrieve-single-metadata-xml! repo group-id artifact-id)]
-                                      (when-let [release (and (string? mta) (parse-meta mta :release))]
-                                        (if (seq release)
-                                          release
-                                          (parse-meta mta :version))))]
+                                      (if-let [release (and (string? mta) (not snapshots?) (parse-meta mta :release))]
+                                        release
+                                        (parse-meta mta :version)))]
                (if-not aggressive?
                  repo-versions
                  (recur rst (concat versions repo-versions)))


### PR DESCRIPTION
Most maven-metadata.xml files include a release tag with the latest released version as the content.  This change checks that tag for content and short circuits the version tag check unless snapshots are requested.  If snapshots are requested, all version tags are collected instead.
