### PR TITLE
make content-type checks insensitive to parameters (after a semicolon)

### DIFF
--- a/src/ancient_clj/io/http.clj
+++ b/src/ancient_clj/io/http.clj
@@ -43,7 +43,8 @@
       (try
         (let [uri (xml/metadata-uri repository-uri group id)
               {:keys [status headers body error]} (http/get uri opts)
-              {:keys [content-type]} headers]
+              {:keys [content-type]} headers
+              content-type (and content-type (first (.split content-type ";")))]
           (if-not error
             (if (= status 200)
               (if (contains? valid-content-types content-type)

--- a/src/ancient_clj/io/s3.clj
+++ b/src/ancient_clj/io/s3.clj
@@ -19,7 +19,8 @@
       (try
         (let [object-id (xml/metadata-uri path group id)
               {:keys [content metadata]} (get! object-id)
-              {:keys [content-type]} metadata]
+              {:keys [content-type]} metadata
+              content-type (and content-type (first (.split content-type ";")))]
           (if (contains? valid-content-types content-type)
             (if content
               (xml/metadata-xml->versions (slurp content))

--- a/test/ancient_clj/io/http_test.clj
+++ b/test/ancient_clj/io/http_test.clj
@@ -68,6 +68,8 @@
     {:status 200
      :headers {"content-type" "text/xml"}}    (throwable? "Could not parse metadata XML")
     {:status 200
+     :headers {"content-type" "text/xml;a=b"}} (throwable? "Could not parse metadata XML")
+    {:status 200
      :headers {"content-type" "text/xml"}
      :body "<not-xml>"}                       (throwable? "Could not parse metadata XML")
     {:status 200

--- a/test/ancient_clj/io/s3_test.clj
+++ b/test/ancient_clj/io/s3_test.clj
@@ -56,6 +56,7 @@
     ?object                                     ?check
     {}                                          (throwable? "content-type is not XML")
     {:metadata {:content-type "text/plain"}}    (throwable? "content-type is not XML")
+    {:metadata {:content-type "text/xml;a=b"}}  (throwable? "content not found")
     {:metadata {:content-type "text/xml"}}      (throwable? "content not found")
     {:content (.getBytes "<not-xml>" "UTF-8")
      :metadata {:content-type "text/xml"}}      (throwable? "Could not parse metadata XML"))


### PR DESCRIPTION
our repo is returning content-type "application/xml;charset=UTF-8" which
is rejected with "response content-type is not XML". this commit makes
the content-type validity check insensitive to the semicolon and
anything that follows.
Please consider accepting this change.