### PR TITLE
Update S3 code for s3-wagon-private

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,11 +8,12 @@
   :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
                  [org.clojure/data.xml "0.0.8"]
                  [version-clj "0.1.2"]
-                 [clj-aws-s3 "0.3.10" :exclusions [com.amazonaws/aws-java-sdk]]
-                 [com.amazonaws/aws-java-sdk-s3 "1.10.66"]
+                 ;; Note that this is the samve version used by s3-wagon-private 1.3.0
+                 [com.amazonaws/aws-java-sdk-s3 "1.11.28"]
                  [clj-http "2.1.0"
                   :exclusions [com.cognitect/transit-clj
                                crouton
+                               org.apache.httpcomponents/httpclient
                                slingshot]]
                  [commons-logging "1.2"]
                  [joda-time "2.9.2"]

--- a/test/ancient_clj/io_test.clj
+++ b/test/ancient_clj/io_test.clj
@@ -21,7 +21,11 @@
   {:uri "s3p://maven/bucket" :username "abc" :passphrase "def"}
   {:uri "s3p://maven/bucket" :username "abc" :password "def"}
   {:url "s3p://maven/bucket" :username "abc" :passphrase "def"}
-  {:uri "s3://maven/bucket" :username "abc" :passphrase "def"})
+  {:uri "s3://maven/bucket" :username "abc" :passphrase "def"}
+  ;; uses default credentials
+  "s3p://maven/bucket"
+  {:uri "s3p://maven/bucket"}
+  {:uri "s3://maven/bucket"})
 
 (tabular
   (fact "about invalid loader specifications."
@@ -30,10 +34,9 @@
   ""                          IllegalArgumentException
   "invalid://abc"             IllegalArgumentException
   "s3p://"                    AssertionError
-  "s3p://maven/bucket"        AssertionError
   "file://repo"               AssertionError
   {}                          IllegalArgumentException
-  {:uri "s3p://maven/bucket"} AssertionError
-  {:uri "s3://maven/bucket"}  AssertionError
   {:uri "s3p://maven/bucket"
-   :username "abc"}           AssertionError)
+   :username "abc"}           AssertionError
+  {:uri "s3p://maven/bucket"
+   :passphrase "def"}         AssertionError)


### PR DESCRIPTION
These changes make the library suitable for use with s3-wagon-private
1.3.0.  In particular, if `:no-auth` is set, the default credentials
provider chain is used and the username/password are ignored.